### PR TITLE
Update tag for new release 0.2.2.

### DIFF
--- a/slurm-spank-stunnel.spec
+++ b/slurm-spank-stunnel.spec
@@ -1,6 +1,6 @@
 Summary: Slurm SPANK plugin for SSH tunneling and port forwarding support
 Name: slurm-spank-stunnel
-Version: 0.2.1
+Version: 0.2.2
 Release: 1 
 License: GPL
 Group: System Environment/Base


### PR DESCRIPTION
Tag master as 0.2.2. Makes using the spec file easier in HMS's autobuild process.

Thanks!